### PR TITLE
Removes access to drag and drop image feature

### DIFF
--- a/sankey.js
+++ b/sankey.js
@@ -264,9 +264,9 @@ function handleDragOver(evt) {
 }
 
 // Setup the dnd listeners.
-var dropZone = document.getElementById('sankey-display');
-dropZone.addEventListener('dragover', handleDragOver, false);
-dropZone.addEventListener('drop', handleFileSelect, false);
+// var dropZone = document.getElementById('sankey-display');
+// dropZone.addEventListener('dragover', handleDragOver, false);
+// dropZone.addEventListener('drop', handleFileSelect, false);
 
 var inputBtn = document.getElementById('selectImageInput');
 inputBtn.onclick = addEventListener('change', handleFileSelect, false);


### PR DESCRIPTION
This removes the ability for a user to drag and drop images into the sankey canvas. This feature is being removed because it wasn't intuitive in nature and presented unnecessary obstetrical. Instead we now expect the user to import images via the image tag and import button.
	
modified:   sankey.js